### PR TITLE
Set bottom screen to RGB8 for the arm9 payload

### DIFF
--- a/include/brahma.h
+++ b/include/brahma.h
@@ -15,6 +15,7 @@ void exploit_arm9_race_condition (void);
 void repair_svcCreateThread (void);
 s32 get_exploit_data (struct exploit_data *data);
 s32 firm_reboot ();
+void set_screen_mode(gfxScreen_t screen_top, gfxScreen_t screen_bottom);
 
 #define BRAHMA_NETWORK_PORT 80
 

--- a/source/brahma.c
+++ b/source/brahma.c
@@ -450,3 +450,11 @@ s32 firm_reboot (void) {
 	/* we do not intend to return ... */
 	return fail_stage;
 }
+
+/* Changes framebuffer mode */
+void set_screen_mode(gfxScreen_t screen_top, gfxScreen_t screen_bottom) {
+    consoleClear();
+    gfxSetScreenFormat(GFX_TOP, screen_top);
+    gfxSetScreenFormat(GFX_BOTTOM, screen_bottom);
+    gfxSwapBuffers();
+}

--- a/source/brahma.c
+++ b/source/brahma.c
@@ -453,8 +453,8 @@ s32 firm_reboot (void) {
 
 /* Changes framebuffer mode */
 void set_screen_mode(gfxScreen_t screen_top, gfxScreen_t screen_bottom) {
-    consoleClear();
-    gfxSetScreenFormat(GFX_TOP, screen_top);
-    gfxSetScreenFormat(GFX_BOTTOM, screen_bottom);
-    gfxSwapBuffers();
+	consoleClear();
+	gfxSetScreenFormat(GFX_TOP, screen_top);
+	gfxSetScreenFormat(GFX_BOTTOM, screen_bottom);
+	gfxSwapBuffers();
 }

--- a/source/brahma.c
+++ b/source/brahma.c
@@ -453,7 +453,6 @@ s32 firm_reboot (void) {
 
 /* Changes framebuffer mode */
 void set_screen_mode(gfxScreen_t screen_top, gfxScreen_t screen_bottom) {
-	consoleClear();
 	gfxSetScreenFormat(GFX_TOP, screen_top);
 	gfxSetScreenFormat(GFX_BOTTOM, screen_bottom);
 	gfxSwapBuffers();

--- a/source/main.c
+++ b/source/main.c
@@ -43,9 +43,9 @@ void interact_with_user (void) {
 s32 quick_boot_firm (s32 load_from_disk) {
 	if (load_from_disk)
 		load_arm9_payload("/arm9payload.bin");
-    set_screen_mode(GSP_BGR8_OES, GSP_BGR8_OES);
+	set_screen_mode(GSP_BGR8_OES, GSP_BGR8_OES);
 	firm_reboot();	
-    consoleInit(GFX_BOTTOM, NULL);
+	consoleInit(GFX_BOTTOM, NULL);
 }
 
 s32 main (void) {

--- a/source/main.c
+++ b/source/main.c
@@ -43,7 +43,9 @@ void interact_with_user (void) {
 s32 quick_boot_firm (s32 load_from_disk) {
 	if (load_from_disk)
 		load_arm9_payload("/arm9payload.bin");
+    set_screen_mode(GSP_BGR8_OES, GSP_BGR8_OES);
 	firm_reboot();	
+    consoleInit(GFX_BOTTOM, NULL);
 }
 
 s32 main (void) {

--- a/source/menus.c
+++ b/source/menus.c
@@ -154,9 +154,9 @@ s32 menu_cb_run (s32 idx, void *param) {
 	soc_exit();
 	printf("[+] Running ARM9 payload\n");	
 
-    set_screen_mode(GSP_BGR8_OES, GSP_BGR8_OES);
+	set_screen_mode(GSP_BGR8_OES, GSP_BGR8_OES);
 	fail_stage = firm_reboot();
-    consoleInit(GFX_BOTTOM, NULL);
+	consoleInit(GFX_BOTTOM, NULL);
 
 	char *msg;
 	switch (fail_stage) {

--- a/source/menus.c
+++ b/source/menus.c
@@ -153,7 +153,10 @@ s32 menu_cb_run (s32 idx, void *param) {
 	   problems with using sockets either */
 	soc_exit();
 	printf("[+] Running ARM9 payload\n");	
+
+    set_screen_mode(GSP_BGR8_OES, GSP_BGR8_OES);
 	fail_stage = firm_reboot();
+    consoleInit(GFX_BOTTOM, NULL);
 
 	char *msg;
 	switch (fail_stage) {


### PR DESCRIPTION
The ConsoleInit function leaves the bottom screen in RGB565 format.
This can be very inconvenient and confusing for ARM9 payloads.
Therefore, I propose this change, that makes sure the bottom screen is set to RGB8 again before reboot.

I admit I haven't checked if the consoleInit actually works for setting the console up again.

Relevant thread: http://4dsdev.org/thread.php?pid=230
